### PR TITLE
[benchmark] Implement SSH key management | 68830

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ override.tf.json
 terraform.rc
 
 .terraform.lock.hcl
+
+# Ignore private keys
+*.pem

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -1,0 +1,47 @@
+# P4 Benchmark - Azure
+
+## Setup
+
+Before runnning the Terraform scripts, you'll need to create the SSH Key pair to assign to the machines and add it to your SSH Agent.
+
+_Note: if you are on Windows, execute all of the following commands in Git Bash to ensure compatibility._
+
+1. Make sure your `az` client is correctly installed and configured:
+```bash
+az login
+
+# Check whether your chosen subscription is correct
+az account show
+```
+
+2. Create a resource group to hold your public key:
+```bash
+export key_name="fgiordano"
+export key_resource_group_name="fgiordano-keys"
+location=eastus # Tweak as needed
+
+az group create --name $key_resource_group_name --location $location
+az sshkey create --name $key_name --resource-group $key_resource_group_name
+```
+
+Notice the new private key has been saved to `~/.ssh/<id>` 
+
+3. Add the SSH Key to your Agent:
+```bash
+# Make sure your Agent is runnning
+eval "$(ssh-agent -s)"
+
+ssh-add "~\.ssh\<id>"
+```
+
+4. Set the Terraform variables related to the SSH Key
+```bash
+# Showing only those specific to the SSH Key
+export TF_VAR_key_name=$key_name
+export TF_VAR_key_resource_group_name=$key_resource_group_name
+```
+
+5. Run Terraform
+```bash
+terraform apply
+```

--- a/terraform/azure/clients.tf
+++ b/terraform/azure/clients.tf
@@ -41,7 +41,7 @@ resource "azurerm_linux_virtual_machine" "locustclients" {
 
   admin_ssh_key {
     username   = "rocky"
-    public_key = file("~/.ssh/id_rsa.pub") # TODO: grab key from Key Vault
+    public_key = data.azurerm_ssh_public_key.rocky-public-key.public_key
   }
 
   os_disk {
@@ -97,8 +97,7 @@ resource "null_resource" "client_cloud_init_status" {
     type        = "ssh"
     user        = "rocky"
     host        = azurerm_linux_virtual_machine.locustclients.0.public_ip_address
-    private_key = file("~/.ssh/id_rsa")
-
+    agent = true
   }
 
   provisioner "remote-exec" {

--- a/terraform/azure/commit.tf
+++ b/terraform/azure/commit.tf
@@ -20,7 +20,7 @@ resource "azurerm_linux_virtual_machine" "helix_core" {
   ]
   admin_ssh_key {
     username   = var.helix_core_admin_user
-    public_key = file("~/.ssh/id_rsa.pub")
+    public_key = data.azurerm_ssh_public_key.rocky-public-key.public_key
   }
 
   os_disk {
@@ -49,7 +49,7 @@ resource "null_resource" "helix_core_cloud_init_status" {
     type        = "ssh"
     user        = var.helix_core_admin_user
     host        = azurerm_linux_virtual_machine.helix_core.public_ip_address
-    private_key = file("~/.ssh/id_rsa")
+    agent = true
   }
 
   provisioner "remote-exec" {

--- a/terraform/azure/driver.tf
+++ b/terraform/azure/driver.tf
@@ -55,7 +55,7 @@ resource "azurerm_linux_virtual_machine" "driver" {
 
   admin_ssh_key {
     username   = "rocky"
-    public_key = file("~/.ssh/id_rsa.pub") # TODO key vault
+    public_key = data.azurerm_ssh_public_key.rocky-public-key.public_key
   }
 
   os_disk {
@@ -110,7 +110,7 @@ resource "null_resource" "driver_cloud_init_status" {
     type        = "ssh"
     user        = "rocky"
     host        = azurerm_linux_virtual_machine.driver.public_ip_address
-    private_key = file("~/.ssh/id_rsa")
+    agent = true
   }
 
   provisioner "remote-exec" {
@@ -127,7 +127,7 @@ resource "null_resource" "upload_create_files" {
     type        = "ssh"
     user        = "rocky"
     host        = azurerm_linux_virtual_machine.driver.public_ip_address
-    private_key = file("~/.ssh/id_rsa")
+    agent = true
   }
 
   provisioner "file" {
@@ -158,7 +158,7 @@ resource "null_resource" "run_create_files" {
     type        = "ssh"
     user        = "rocky"
     host        = azurerm_linux_virtual_machine.driver.public_ip_address
-    private_key = file("~/.ssh/id_rsa")
+    agent = true
   }
 
   provisioner "remote-exec" {
@@ -175,7 +175,7 @@ resource "null_resource" "apply_p4d_configurables" {
     type        = "ssh"
     user        = "rocky"
     host        = local.helix_core_public_ip
-    private_key = file("~/.ssh/id_rsa")
+    agent = true
   }
 
   provisioner "remote-exec" {
@@ -194,7 +194,7 @@ resource "null_resource" "remove_p4d_configurables" {
     type        = "ssh"
     user        = "rocky"
     host        = local.helix_core_public_ip
-    private_key = file("~/.ssh/id_rsa")
+    agent = true
   }
 
   provisioner "remote-exec" {

--- a/terraform/azure/ssh_key.tf
+++ b/terraform/azure/ssh_key.tf
@@ -2,3 +2,8 @@ resource "tls_private_key" "ssh-key" {
   algorithm = "RSA"
   rsa_bits  = 4096
 }
+
+data "azurerm_ssh_public_key" "rocky-public-key" {
+  name                = var.key_name
+  resource_group_name = var.key_resource_group_name
+}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -252,3 +252,13 @@ variable "createfile_configs" {
     }
   ]
 }
+
+variable "key_name" {
+  description = "Key name of the existing Key Pair to use for all instances."
+  type        = string
+}
+
+variable "key_resource_group_name" {
+  description = "Resource Group name of the existing Key Pair to use for all instances."
+  type        = string
+}


### PR DESCRIPTION
### Ticket

[68830](https://dev.azure.com/southworks/lycoris/_workitems/edit/68830)

### Changes

- Retrieve public key for Rocky user in VMs from Azure SSH Keys
- Get private keys for `remote_exec`s from SSH Agent, not file.
- Add README with configuration instructions via `az`

### Details

We now require the SSH key to be created before-hand in Azure, so that the VM accesses are not restricted to a personal private key. Note that only the public key will be stored in Azure, _not_ the private key.